### PR TITLE
#8 publish example to github

### DIFF
--- a/examples/package.json
+++ b/examples/package.json
@@ -8,7 +8,8 @@
   "scripts": {
     "start": "set NODE_ENV=development && webpack-dev-server --inline --hot --port=3000 --history-api-fallback",
     "build": "NODE_ENV=production webpack --define process.env.NODE_ENV='\"production\"' -p ",
-    "lint": "eslint src && find ./src/ -iname \"*.scss\" -exec sass-lint -v -q {} +"
+    "lint": "eslint src && find ./src/ -iname \"*.scss\" -exec sass-lint -v -q {} +",
+    "publish_gh_pages": "node publish"
   },
   "author": "Fabien JUIF",
   "license": "MIT",
@@ -34,6 +35,7 @@
     "eslint-plugin-react": "^6.0.0",
     "expect": "~1.16.0",
     "file-loader": "~0.8.5",
+    "gh-pages": "^0.11.0",
     "jsdom": "^9.4.2",
     "mocha": "~2.4.5",
     "node-sass": "^3.7.0",

--- a/examples/publish.js
+++ b/examples/publish.js
@@ -1,0 +1,10 @@
+var ghpages = require('gh-pages');
+var path = require('path');
+
+ghpages.publish(path.join(__dirname, 'public'), function(err) {
+  if(err) {
+    console.error(err)
+  } else {
+    console.log("Success")
+  }
+});

--- a/examples/src/components/App.jsx
+++ b/examples/src/components/App.jsx
@@ -2,7 +2,7 @@ import React from 'react'
 
 import Examples from './Examples'
 import styles from './App.scss'
-import Icon from 'file?name=[name].[ext]!../favicon.gif'
+import Icon from 'favicon.gif'
 
 const App = () => (
   <div className={styles.app}>

--- a/examples/webpack.config.js
+++ b/examples/webpack.config.js
@@ -58,6 +58,9 @@ module.exports = {
         'css?modules&localIdentName=[path]_[local]__[hash:base64:5]',
         'sass',
       ],
-    }],
+    }, {
+      test: /\.(png|svg|gif|jpg)$/,
+      loader: 'file?name=./src/[name].[ext]',
+    },],
   },
 }

--- a/examples/webpack.config.js
+++ b/examples/webpack.config.js
@@ -39,7 +39,7 @@ module.exports = {
   output: {
     path: path.join(__dirname, 'public'),
     filename: '[name].js',
-    publicPath: '/',
+    publicPath: './',
   },
   resolve: {
     root: [path.resolve('./src'), path.resolve('./src/components')],
@@ -60,7 +60,7 @@ module.exports = {
       ],
     }, {
       test: /\.(png|svg|gif|jpg)$/,
-      loader: 'file?name=./src/[name].[ext]',
+      loader: 'file?name=[name].[ext]',
     },],
   },
 }


### PR DESCRIPTION
Support for publish Examples in github pages #8. To use it :

``` shell
npm run build
npm run publish_gh_pages
```

I had a some trouble with webpack-file-loader. It prepend a slash before the file url, and then the _favicon.gif_ file doesn't display in main page. I use ./src to display the image.
Maybe there is a better solution.

The examples are available here => http://nebulis.github.io/react-animate/
